### PR TITLE
fix: RefObject.current readonly type

### DIFF
--- a/packages/v1/provider/index.tsx
+++ b/packages/v1/provider/index.tsx
@@ -6,11 +6,11 @@ import React, {
   useEffect,
 } from 'react';
 import { ExternalPopupContext } from '../context';
-import { PopupContext, Animation } from '../types';
+import { PopupContext, Animation, Mutable } from '../types';
 
 interface ProviderProps<T> {
   Component: React.FC<T>;
-  internalRef: React.RefObject<PopupContext<T>>;
+  internalRef: Mutable<React.RefObject<PopupContext<T>>>;
 }
 
 function Provider<T>({ Component, internalRef }: ProviderProps<T>) {
@@ -42,13 +42,9 @@ function Provider<T>({ Component, internalRef }: ProviderProps<T>) {
 
   useImperativeHandle(internalRef, () => context, []);
 
-  /**
-   * FIXME: any other way to do this??😭
-   */
   useEffect(() => {
     return () => {
       if (prevRef.current) {
-        //@ts-ignore
         internalRef.current = prevRef.current;
       }
       animations.current = [];

--- a/packages/v1/types/index.ts
+++ b/packages/v1/types/index.ts
@@ -9,3 +9,7 @@ export interface UsePopupContext {
 }
 
 export type Animation = () => Promise<void>;
+
+export type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+};


### PR DESCRIPTION
## Summary
created a `Mutable type` that inverts the readonly type to a public type and used it for the ProviderProps.

```ts
type Mutable<T> = {
  -readonly [P in keyof T]: T[P];
}
```

## Test Plan
It didn't seem like it needed testing, but I tested it using Storybook.